### PR TITLE
Add script to fetch hourly AI news

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # aicodingtest
+
+This repository contains a simple script that prints the latest AI-related news from DuckDuckGo every hour.
+
+## Requirements
+- Python 3.11+
+- The `duckduckgo_search` package. Install with:
+  ```bash
+  pip install duckduckgo_search
+  ```
+
+## Usage
+Run the script directly:
+```bash
+python ai_news.py
+```
+It will display the top 10 news articles about Artificial Intelligence and refresh every hour.

--- a/ai_news.py
+++ b/ai_news.py
@@ -1,0 +1,21 @@
+import time
+from datetime import datetime
+from duckduckgo_search import DDGS
+
+QUERY = "artificial intelligence"
+RESULTS = 10
+SLEEP_SECONDS = 3600
+
+def fetch_news():
+    with DDGS() as ddgs:
+        return list(ddgs.news(QUERY, max_results=RESULTS))
+
+def main():
+    while True:
+        print(f"\n{datetime.now():%Y-%m-%d %H:%M:%S} - Top {RESULTS} news about '{QUERY}':\n")
+        for i, res in enumerate(fetch_news(), start=1):
+            print(f"{i}. {res['title']}\n   {res['url']}")
+        time.sleep(SLEEP_SECONDS)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `ai_news.py` to fetch and print latest AI news via DuckDuckGo Search
- document requirements and usage in `README.md`

## Testing
- `python -m py_compile ai_news.py`


------
https://chatgpt.com/codex/tasks/task_e_6840066a8d2883338032438167082d64